### PR TITLE
Recommendation algorithm

### DIFF
--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -77,9 +77,7 @@ export default function Dashboard() {
           {availableSessions.map((element, index) => (
             <SessionCard
               key={index}
-              name={element.name}
-              description={element.description}
-              groupId={element.groupId}
+              session={element}
               onMoreInfo={openSessionMoreInfoModal}
             />
           ))}
@@ -90,9 +88,7 @@ export default function Dashboard() {
           {availableSessions.map((element, index) => (
             <SessionCard
               key={index}
-              name={element.name}
-              description={element.description}
-              groupId={element.groupId}
+              session={element}
               onMoreInfo={openSessionMoreInfoModal}
             />
           ))}

--- a/client/src/components/MySessions/MySessions.jsx
+++ b/client/src/components/MySessions/MySessions.jsx
@@ -42,7 +42,7 @@ export default function MySessions() {
             <div className="sessionsCont">
                 <ul className="sessions">
                     {joinedSessions.map((element, index) => (
-                        <SessionCard joined={element.joined} key={index} name={element.name} description={element.description} groupId={element.groupId} onMoreInfo={openSessionMoreInfoModal} /> 
+                        <SessionCard key={index} session={element} onMoreInfo={openSessionMoreInfoModal} /> 
                     ))}
                 </ul>            
 

--- a/client/src/components/Navbar/Navbar.jsx
+++ b/client/src/components/Navbar/Navbar.jsx
@@ -79,8 +79,9 @@ export default function Navbar() {
 
   const updateSession = () => {
     let session = recommendedSession;
-    session.members.push(profile.name);
-    dispatch(updateSessionAsync(session));
+    let updatedMembers = [...session.members, profile.name];
+    let updatedSession = { ...session, members: updatedMembers };
+    dispatch(updateSessionAsync(updatedSession));
   }
 
   return (

--- a/client/src/components/Navbar/Navbar.jsx
+++ b/client/src/components/Navbar/Navbar.jsx
@@ -13,6 +13,7 @@ import "../styles.module.css"
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
+import { useSelector } from 'react-redux';
 
 
 // Code from Material UI docs for AppBar
@@ -61,6 +62,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
 
 // Code from Material UI docs for AppBar
 export default function Navbar() {
+    const recommendedSession = useSelector((store) => store.sessionReducer).recommendedSession;
     const [anchorEl, setAnchorEl] = React.useState(null);
 
       const handleMenu = (event) => {
@@ -91,6 +93,11 @@ export default function Navbar() {
               inputProps={{ 'aria-label': 'search' }}
             />
           </Search>
+          <Link to={`/join?groupId=${recommendedSession.groupId}`} style={{ color: 'white' }}>
+                <MenuItem>
+                  Magic Join
+                </MenuItem>
+          </Link>
           <Link to="/mysessions" style={{ color: 'white' }}>
                 <MenuItem>
                   My Sessions

--- a/client/src/components/Navbar/Navbar.jsx
+++ b/client/src/components/Navbar/Navbar.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useDispatch, useSelector } from "react-redux";
 import { styled, alpha } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
@@ -9,11 +10,11 @@ import InputBase from '@mui/material/InputBase';
 import SearchIcon from '@mui/icons-material/Search';
 import { Link } from 'react-router-dom';
 import "../styles.module.css"
+import { updateSessionAsync } from '../../redux/session/sessionThunks';
 
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
-import { useSelector } from 'react-redux';
 
 
 // Code from Material UI docs for AppBar
@@ -62,19 +63,29 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
 
 // Code from Material UI docs for AppBar
 export default function Navbar() {
-    const recommendedSession = useSelector((store) => store.sessionReducer).recommendedSession;
-    const [anchorEl, setAnchorEl] = React.useState(null);
+  const dispatch = useDispatch();
 
-      const handleMenu = (event) => {
-        setAnchorEl(event.currentTarget);
-      };
-    
-      const handleClose = () => {
-        setAnchorEl(null);
-      };
+  const recommendedSession = useSelector((store) => store.sessionReducer).recommendedSession;
+  const profile = useSelector((store) => store.profileReducer).profile;
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const updateSession = () => {
+    let session = recommendedSession;
+    session.members.push(profile.name);
+    dispatch(updateSessionAsync(session));
+  }
+
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static" sx={{backgroundColor: 'coral'}}>
+      <AppBar position="static" sx={{ backgroundColor: 'coral' }}>
         <Toolbar>
           <Typography
             variant="h6"
@@ -94,47 +105,47 @@ export default function Navbar() {
             />
           </Search>
           <Link to={`/join?groupId=${recommendedSession.groupId}`} style={{ color: 'white' }}>
-                <MenuItem>
-                  Magic Join
-                </MenuItem>
+            <MenuItem onClick={updateSession}>
+              Magic Join
+            </MenuItem>
           </Link>
           <Link to="/mysessions" style={{ color: 'white' }}>
-                <MenuItem>
-                  My Sessions
-                </MenuItem>
+            <MenuItem>
+              My Sessions
+            </MenuItem>
           </Link>
-              <IconButton
-                size="large"
-                aria-label="account of current user"
-                aria-controls="menu-appbar"
-                aria-haspopup="true"
-                onClick={handleMenu}
-                color="inherit"
-              >
-                <AccountCircle />
-              </IconButton>
-              <Menu
-                id="menu-appbar"
-                anchorEl={anchorEl}
-                anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'left',
-                }}
-                keepMounted
-                transformOrigin={{
-                  vertical: 'top',
-                  horizontal: 'left',
-                }}
-                open={Boolean(anchorEl)}
-                onClose={handleClose}
-              >
-              <Link to="/profile" style={{ color: 'black' }}>
-                <MenuItem>
-                  Profile
-                </MenuItem>
-              </Link>
-              <MenuItem onClick={handleClose}>Log out</MenuItem>
-              </Menu>
+          <IconButton
+            size="large"
+            aria-label="account of current user"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleMenu}
+            color="inherit"
+          >
+            <AccountCircle />
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+          >
+            <Link to="/profile" style={{ color: 'black' }}>
+              <MenuItem>
+                Profile
+              </MenuItem>
+            </Link>
+            <MenuItem onClick={handleClose}>Log out</MenuItem>
+          </Menu>
         </Toolbar>
       </AppBar>
     </Box>

--- a/client/src/components/Profile/Profile.jsx
+++ b/client/src/components/Profile/Profile.jsx
@@ -53,8 +53,10 @@ export default function Profile() {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    dispatch(updateProfileAsync(formData));
-    formData.storedName = formData.name;
+    dispatch(updateProfileAsync(formData)).then(() => {
+      formData.storedName = formData.name;
+      window.location.reload(false);
+    });
   };
 
   return (

--- a/client/src/components/SessionCard/SessionCard.jsx
+++ b/client/src/components/SessionCard/SessionCard.jsx
@@ -6,32 +6,49 @@ import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from "react-redux";
+import { updateSessionAsync } from '../../redux/session/sessionThunks';
 
 export default function SessionCard(props) {
+  const dispatch = useDispatch();
+
+  const profile = useSelector((store) => store.profileReducer).profile;
   const [isMoreInfoOpen, setIsMoreInfoOpen] = useState(false);
 
   const handleOpenMoreInfo = () => {
     setIsMoreInfoOpen(true);
-    props.onMoreInfo(props.groupId);
+    props.onMoreInfo(props.session.groupId);
   };
 
-    function joinButton() {
-        // dispatch to change joined value for this session = true
-    }
+  function joinButton() {
+    let session = props.session;
+    let updatedMembers = [...session.members, profile.name];
+    let updatedSession = { ...session, members: updatedMembers };
+    dispatch(updateSessionAsync(updatedSession));
+  }
 
-    return (
+  const leaveButton = () => {
+    let session = props.session;
+    let updatedMembers = session.members.filter(member => member !== profile.name);
+    let updatedSession = { ...session, members: updatedMembers };
+    dispatch(updateSessionAsync(updatedSession));
+  };
+
+  const isMember = props.session.members.includes(profile.name);
+
+  return (
     <Card sx={{ maxWidth: '250px', minWidth: '250px', backgroundColor: 'white', display: 'flex', flexDirection: 'column' }}>
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">
-          {props.name}
+          {props.session.name}
         </Typography>
         <Typography gutterBottom variant="p" component="div">
-          {props.description}
+          {props.session.description}
         </Typography>
       </CardContent>
       <CardActions style={{ marginTop: 'auto' }}>
-        {!props.joined && (
-          <Link to={`/join?groupId=${props.groupId}`} style={{ marginRight: '10px' }}>
+        {!isMember && (
+          <Link to={`/join?groupId=${props.session.groupId}`} style={{ marginRight: '10px' }}>
             <Button
               sx={{ color: 'white', backgroundColor: 'lightsalmon', textTransform: 'none' }}
               size="small" onClick={joinButton}
@@ -39,6 +56,11 @@ export default function SessionCard(props) {
               Join
             </Button>
           </Link>
+        )}
+        {isMember && (
+          <Button sx={{ color: 'white', backgroundColor: 'lightsalmon', textTransform: 'none' }} size="small" onClick={leaveButton}>
+            Leave
+          </Button>
         )}
         <Button
           onClick={handleOpenMoreInfo}

--- a/client/src/redux/session/actionTypes.js
+++ b/client/src/redux/session/actionTypes.js
@@ -2,5 +2,6 @@ export const actionTypes = {
     GET_SESSIONS: 'session/getsessions',
     GET_FEATURED_SESSIONS: 'session/getfeaturedsessions',
     GET_RECOMMENDED_SESSION: 'session/getrecommendedsession',
-    CREATE_NEW_SESSION: 'session/createnewsession'
+    CREATE_NEW_SESSION: 'session/createnewsession',
+    UPDATE_SESSION: 'session/updatesession'
 };

--- a/client/src/redux/session/actionTypes.js
+++ b/client/src/redux/session/actionTypes.js
@@ -1,5 +1,6 @@
 export const actionTypes = {
     GET_SESSIONS: 'session/getsessions',
-    GET_FEATURED_SESSIONS: 'session/getfeaturedsession',
+    GET_FEATURED_SESSIONS: 'session/getfeaturedsessions',
+    GET_RECOMMENDED_SESSION: 'session/getrecommendedsession',
     CREATE_NEW_SESSION: 'session/createnewsession'
 };

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { REQUEST_STATE } from '../utils';
-import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync } from './sessionThunks';
+import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync, updateSessionAsync } from './sessionThunks';
 import sessionService from './sessionService';
 import profileService from '../profile/profileService'
 
@@ -18,6 +18,7 @@ const INITIAL_STATE = {
     getFeaturedSessions: REQUEST_STATE.IDLE,
     getRecommendedSession: REQUEST_STATE.IDLE,
     createNewSession: REQUEST_STATE.IDLE,
+    updateSession: REQUEST_STATE.IDLE,
     error: null
 };
 
@@ -108,6 +109,35 @@ const sessionSlice = createSlice({
                 return {
                     ...state,
                     createNewSession: REQUEST_STATE.REJECTED,
+                    error: action.error
+                }
+            })
+            .addCase(updateSessionAsync.pending, (state) => {
+                return {
+                    ...state,
+                    updateSession: REQUEST_STATE.PENDING,
+                    error: null
+                }
+            })
+            .addCase(updateSessionAsync.fulfilled, (state, action) => {
+                const updatedSession = action.payload;
+                const updatedSessions = state.sessions.map(session => {
+                    if (session.groupId === updatedSession.groupId) {
+                        return updatedSession;
+                    }
+                    return session;
+                });
+
+                return {
+                    ...state,
+                    updateSession: REQUEST_STATE.FULFILLED,
+                    sessions: updatedSessions
+                };
+            })
+            .addCase(updateSessionAsync.rejected, (state, action) => {
+                return {
+                    ...state,
+                    updateSession: REQUEST_STATE.REJECTED,
                     error: action.error
                 }
             });

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -1,13 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { REQUEST_STATE } from '../utils';
-import { getSessionsAsync, getFeaturedSessionsAsync, createNewSessionAsync } from './sessionThunks';
+import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync } from './sessionThunks';
 import sessionService from './sessionService';
 
 const INITIAL_STATE = {
     sessions: await sessionService.getSessions(),
     featuredSessions: await sessionService.getFeaturedSessions(),
+    recommendedSession: {},
     getSessions: REQUEST_STATE.IDLE,
     getFeaturedSessions: REQUEST_STATE.IDLE,
+    getRecommendedSession: REQUEST_STATE.IDLE,
     createNewSession: REQUEST_STATE.IDLE,
     error: null
 };
@@ -57,6 +59,27 @@ const sessionSlice = createSlice({
                 return {
                     ...state,
                     getFeaturedSessions: REQUEST_STATE.REJECTED,
+                    error: action.error
+                }
+            })
+            .addCase(getRecommendedSessionAsync.pending, (state) => {
+                return {
+                    ...state,
+                    getRecommendedSession: REQUEST_STATE.PENDING,
+                    error: null
+                }
+            })
+            .addCase(getRecommendedSessionAsync.fulfilled, (state, action) => {
+                return {
+                    ...state,
+                    getRecommendedSession: REQUEST_STATE.FULFILLED,
+                    recommendedSession: action.payload
+                }
+            })
+            .addCase(getRecommendedSessionAsync.rejected, (state, action) => {
+                return {
+                    ...state,
+                    getRecommendedSession: REQUEST_STATE.REJECTED,
                     error: action.error
                 }
             })

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -2,10 +2,17 @@ import { createSlice } from '@reduxjs/toolkit';
 import { REQUEST_STATE } from '../utils';
 import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync } from './sessionThunks';
 import sessionService from './sessionService';
+import profileService from '../profile/profileService'
+
+let sessions = await sessionService.getSessions();
+let profile = await profileService.getProfile();
+let featuredSessions = await Promise.all([sessions, profile]).then(async (values) => {
+    return sessionService.getFeaturedSessions(values[1], values[0])
+});
 
 const INITIAL_STATE = {
-    sessions: await sessionService.getSessions(),
-    featuredSessions: await sessionService.getFeaturedSessions(),
+    sessions: sessions,
+    featuredSessions: await featuredSessions,
     recommendedSession: {},
     getSessions: REQUEST_STATE.IDLE,
     getFeaturedSessions: REQUEST_STATE.IDLE,

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -13,7 +13,7 @@ let featuredSessions = await Promise.all([sessions, profile]).then(async (values
 const INITIAL_STATE = {
     sessions: sessions,
     featuredSessions: await featuredSessions,
-    recommendedSession: {},
+    recommendedSession: featuredSessions[0],
     getSessions: REQUEST_STATE.IDLE,
     getFeaturedSessions: REQUEST_STATE.IDLE,
     getRecommendedSession: REQUEST_STATE.IDLE,

--- a/client/src/redux/session/sessionService.js
+++ b/client/src/redux/session/sessionService.js
@@ -10,7 +10,20 @@ const getSessions = async (sport = '') => {
 }
 
 const getFeaturedSessions = async () => {
-    const response = await fetch('http://localhost:3001/session/featured')
+    const response = await fetch('http://localhost:3001/session/featured');
+
+    return await response.json()
+}
+
+const getRecommendedSession = async (profile, sessions) => {
+    let body = {
+        profile: profile,
+        sessions: sessions
+    }
+    const response = await fetch('http://localhost:3001/session/recommended', {
+        method: "GET",
+        body: JSON.stringify(body)
+    })
 
     return await response.json()
 }
@@ -30,5 +43,6 @@ const createNewSession = async (new_session) => {
 export default {
     getSessions,
     getFeaturedSessions,
+    getRecommendedSession,
     createNewSession
 };

--- a/client/src/redux/session/sessionService.js
+++ b/client/src/redux/session/sessionService.js
@@ -54,9 +54,22 @@ const createNewSession = async (new_session) => {
     return await response.json()
 }
 
+const updateSession = async (session) => {
+    var response = await fetch('http://localhost:3001/session', {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(session)
+    })
+
+    return await response.json()
+}
+
 export default {
     getSessions,
     getFeaturedSessions,
     getRecommendedSession,
-    createNewSession
+    createNewSession,
+    updateSession
 };

--- a/client/src/redux/session/sessionService.js
+++ b/client/src/redux/session/sessionService.js
@@ -9,8 +9,19 @@ const getSessions = async (sport = '') => {
     return await response.json()
 }
 
-const getFeaturedSessions = async () => {
-    const response = await fetch('http://localhost:3001/session/featured');
+const getFeaturedSessions = async (profile, sessions) => {
+    let body = {
+        profile: profile,
+        sessions: sessions
+    }
+
+    const response = await fetch('http://localhost:3001/session/featured', {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(body)
+    })
 
     return await response.json()
 }
@@ -21,7 +32,10 @@ const getRecommendedSession = async (profile, sessions) => {
         sessions: sessions
     }
     const response = await fetch('http://localhost:3001/session/recommended', {
-        method: "GET",
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
         body: JSON.stringify(body)
     })
 

--- a/client/src/redux/session/sessionThunks.js
+++ b/client/src/redux/session/sessionThunks.js
@@ -29,3 +29,10 @@ export const createNewSessionAsync = createAsyncThunk(
         return await sessionService.createNewSession(new_session);
     }
 );
+
+export const updateSessionAsync = createAsyncThunk(
+    actionTypes.UPDATE_SESSION,
+    async (session) => {
+        return await sessionService.updateSession(session);
+    }
+);

--- a/client/src/redux/session/sessionThunks.js
+++ b/client/src/redux/session/sessionThunks.js
@@ -11,14 +11,14 @@ export const getSessionsAsync = createAsyncThunk(
 
 export const getFeaturedSessionsAsync = createAsyncThunk(
     actionTypes.GET_FEATURED_SESSIONS,
-    async () => {
-        return await sessionService.getFeaturedSessions();
+    async ({profile, sessions}) => {
+        return await sessionService.getFeaturedSessions(profile, sessions);
     }
 );
 
 export const getRecommendedSessionAsync = createAsyncThunk(
     actionTypes.GET_RECOMMENDED_SESSION,
-    async (profile, sessions) => {
+    async ({profile, sessions}) => {
         return await sessionService.getRecommendedSession(profile, sessions);
     }
 );

--- a/client/src/redux/session/sessionThunks.js
+++ b/client/src/redux/session/sessionThunks.js
@@ -16,6 +16,13 @@ export const getFeaturedSessionsAsync = createAsyncThunk(
     }
 );
 
+export const getRecommendedSessionAsync = createAsyncThunk(
+    actionTypes.GET_RECOMMENDED_SESSION,
+    async (profile, sessions) => {
+        return await sessionService.getRecommendedSession(profile, sessions);
+    }
+);
+
 export const createNewSessionAsync = createAsyncThunk(
     actionTypes.CREATE_NEW_SESSION,
     async (new_session) => {

--- a/server/algorithms/sessionRecommendationAlgorithm.js
+++ b/server/algorithms/sessionRecommendationAlgorithm.js
@@ -5,6 +5,18 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
     let counter = 0;
     let ret = [];
 
+    if (!sessions) {
+        return ret;
+    }
+
+    if (!profile) {
+        let size = sessions.length > number ? number : sessions.length;
+        for (let i = 0; i < size; i++) {
+            ret[i] = availableSessions[i];
+        }
+        return ret;
+    }
+
     const previousSessions = sessions.filter(
         (session) => session.members && session.members.includes(profile.name)
     );
@@ -54,7 +66,8 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
         counter++;
     });
 
-    for (let i = 0; i < number; i++) {
+    let size = availableSessions.length > number ? number : availableSessions.length;
+    for (let i = 0; i < size; i++) {
         let index = sessionScores.indexOf(Math.max(...sessionScores));
         sessionScores[index] = 0;
         ret[i] = availableSessions[index];

--- a/server/algorithms/sessionRecommendationAlgorithm.js
+++ b/server/algorithms/sessionRecommendationAlgorithm.js
@@ -1,0 +1,42 @@
+const pointValues = require('./sessionRecommendationPointValues');
+
+function sessionRecommendationAlgorithm(profile, sessions, number) {
+    let sessionScores = [];
+    let counter = 0;
+    let ret = [];
+
+    sessions.forEach(session => {
+        let sessionScore = 0;
+
+        profile.equipment.forEach((item) => {
+            if (session.equipment[0].includes(item)) {
+                sessionScore = sessionScore + pointValues.MATCHING_EQUIPMENT;
+            }
+        })
+
+        if (session.city === profile.location) {
+            sessionScore = sessionScore + pointValues.SAME_LOCATION;
+        }
+
+        if (session.playersNeeded <= 3 && session.playersNeeded > 0) {
+            sessionScore = sessionScore + pointValues.PLAYER_COUNT - session.playersNeeded;
+        }
+
+        if (profile.interests.includes(session.sport)) {
+            sessionScore = sessionScore + pointValues.MATCHING_INTEREST;
+        }
+
+        sessionScores[counter] = sessionScore;
+        counter++;
+    });
+
+    for (let i = 0; i < number; i++) {
+        let index = sessionScores.indexOf(Math.max(...sessionScores));
+        sessionScores[index] = 0;
+        ret[i] = sessions[index];
+    }
+
+    return ret;
+}
+
+module.exports = sessionRecommendationAlgorithm;

--- a/server/algorithms/sessionRecommendationAlgorithm.js
+++ b/server/algorithms/sessionRecommendationAlgorithm.js
@@ -5,7 +5,15 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
     let counter = 0;
     let ret = [];
 
-    sessions.forEach(session => {
+    const previousSessions = sessions.filter(
+        (session) => session.members && session.members.includes(profile.name)
+    );
+
+    const availableSessions = sessions.filter(
+        (session) => session.members && !session.members.includes(profile.name) && session.playersNeeded > 0
+    );
+
+    availableSessions.forEach(session => {
         let sessionScore = 0;
 
         profile.equipment.forEach((item) => {
@@ -26,6 +34,24 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
             sessionScore = sessionScore + pointValues.MATCHING_INTEREST;
         }
 
+        previousSessions.forEach((prevSession) => {
+            if (session.city === prevSession.city) {
+                sessionScore = sessionScore + pointValues.HISTORY_SIMILARITY;
+
+                if (session.location === prevSession.location) {
+                    sessionScore = sessionScore + pointValues.HISTORY_SIMILARITY;
+                }
+            }
+
+            sessionScore = sessionScore + prevSession.members.filter(member => session.members.includes(member)).length * pointValues.HISTORY_SIMILARITY;
+
+            if (session.sport === prevSession.sport) {
+                sessionScore = sessionScore + pointValues.HISTORY_SIMILARITY;
+            }
+        });
+
+        console.log(sessionScore);
+
         sessionScores[counter] = sessionScore;
         counter++;
     });
@@ -33,7 +59,7 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
     for (let i = 0; i < number; i++) {
         let index = sessionScores.indexOf(Math.max(...sessionScores));
         sessionScores[index] = 0;
-        ret[i] = sessions[index];
+        ret[i] = availableSessions[index];
     }
 
     return ret;

--- a/server/algorithms/sessionRecommendationAlgorithm.js
+++ b/server/algorithms/sessionRecommendationAlgorithm.js
@@ -50,8 +50,6 @@ function sessionRecommendationAlgorithm(profile, sessions, number) {
             }
         });
 
-        console.log(sessionScore);
-
         sessionScores[counter] = sessionScore;
         counter++;
     });

--- a/server/algorithms/sessionRecommendationPointValues.js
+++ b/server/algorithms/sessionRecommendationPointValues.js
@@ -1,0 +1,9 @@
+const pointValues = {
+    MATCHING_EQUIPMENT: 1,
+    SAME_LOCATION: 5,
+    PLAYER_COUNT: 4,
+    MATCHING_INTEREST: 5,
+    HISTORY_SIMILARITY: 1
+};
+
+module.exports = pointValues;

--- a/server/app.js
+++ b/server/app.js
@@ -16,7 +16,7 @@ connectDB();
 
 app.use(cors());
 app.use(logger('dev'));
-app.use(express.json());
+app.use(express.json({ limit: '1000mb' }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));

--- a/server/mongo/models/sessionModel.js
+++ b/server/mongo/models/sessionModel.js
@@ -26,12 +26,12 @@ const sessionSchema = new mongoose.Schema({
         required: true,
     },
     groupId: {
-        type: Number,
+        type: String,
         required: true,
     },
     image: {
         type: String,
-        required: true,
+        required: false,
     },
     sport: {
         type: String,

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -174,6 +174,14 @@ router.post('/', async function (req, res, next) {
     return res.status(200).send(new_session);
 });
 
+// UPDATE a session
+router.patch('/', async function (req, res, next) {
+    let session = req.body;
+    await sessionQueries.updateSession(session);
+
+    return res.status(200).send(session);
+});
+
 // GET featured sessions
 router.post('/featured', function (req, res, next) {
     let profile = req.body.profile;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -1,3 +1,5 @@
+const sessionRecommendationAlgorithm = require('../algorithms/sessionRecommendationAlgorithm');
+
 const express = require('express');
 const sessionQueries = require('../mongo/queries/sessionQueries');
 const router = express.Router();
@@ -175,6 +177,16 @@ router.post('/', async function (req, res, next) {
 // GET featured sessions
 router.get('/featured', function (req, res, next) {
     return res.status(200).send(featuredSessions);
+});
+
+// GET Recommended session for magic join
+router.get('/recommended', function (req, res, next) {
+    let profile = req.body.profile;
+    let sessions = req.body.sessions;
+
+    let session = sessionRecommendationAlgorithm(profile, sessions, 1)[0];
+
+    return res.status(200).send(session);
 });
 
 module.exports = router;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -175,12 +175,17 @@ router.post('/', async function (req, res, next) {
 });
 
 // GET featured sessions
-router.get('/featured', function (req, res, next) {
+router.post('/featured', function (req, res, next) {
+    let profile = req.body.profile;
+    let sessions = req.body.sessions;
+
+    let featuredSessions = sessionRecommendationAlgorithm(profile, sessions, 3);
+
     return res.status(200).send(featuredSessions);
 });
 
 // GET Recommended session for magic join
-router.get('/recommended', function (req, res, next) {
+router.post('/recommended', function (req, res, next) {
     let profile = req.body.profile;
     let sessions = req.body.sessions;
 


### PR DESCRIPTION
Ran through all workflows and should have no regression.

Added the recommendation algorithm. It is based on profile data, as well as other sessions a user has joined. There's no real reason I made the algorithm exactly the way I did, I tried to make it easy to update in the future by using constants for point weightings. Usually a company might use AI or user feedback to perfect that kind of thing, but for our cases, we're stuck with guessing.
The algorithm now runs on the 'recommended sessions' carousel, where the sessions shown are the top sessions returned by the algorithm. 
I have also added a Magic Join button to the nav bar that automatically has the user join their top recommended session. It redirects them to the session's join page.

I also added joining/leaving functionality because it was bothering me (sorry it's not in a different PR). Manual joins and magic join now actually update the members field of the session. The session will no longer be displayed on the dashboard, and will now appear under my sessions. Joined sessions now have a leave button that makes them leave the session, which in turn will make the session reappear in the dashboard and disappear from the my sessions page.