### PR TITLE
JoinedSession page routing fix

### DIFF
--- a/client/src/components/JoinSession/JoinSession.jsx
+++ b/client/src/components/JoinSession/JoinSession.jsx
@@ -143,7 +143,7 @@ export default function JoinSession() {
                     <Map session={session}/>
                 </div>
                 <div className="end">
-                    <Link to={{ pathname: '/' }} style={{ marginRight: '10px', textDecoration: 'none' }}>
+                    <Link to={{ pathname: '/dashboard' }} style={{ marginRight: '10px', textDecoration: 'none' }}>
                         <span className="closeButton">
                             &times;
                         </span>

--- a/client/src/redux/profile/profileService.js
+++ b/client/src/redux/profile/profileService.js
@@ -12,8 +12,6 @@ const getProfile = async () => {
         }
 
         const message = await response.json();
-        console.log(email);
-        console.log(message);
         return message;
     } catch (error) {
         console.error('Error fetching profile:', error.message);


### PR DESCRIPTION
- Clicking 'X' on the joined session page now routes to the dashboard instead of log in
- Removed some sneaky console logs