### PR TITLE
Session Owner Update/Delete Sessions

### DIFF
--- a/client/src/components/CreateSession/CreateSessionTextFields.jsx
+++ b/client/src/components/CreateSession/CreateSessionTextFields.jsx
@@ -94,6 +94,7 @@ export default function CreateSessionTextFields(props) {
             sport: session_sport,
             dateTime: session_date_time,
             members: [profile],
+            owner: profile.email,
             groupId: groupId,
         };
 

--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -42,8 +42,6 @@ export default function Dashboard() {
     setIsSessionMoreInfoModalOpen(false);
   };
 
-  
-
   return (
     <div className="container">
       <Navbar />

--- a/client/src/components/JoinSession/JoinSession.css
+++ b/client/src/components/JoinSession/JoinSession.css
@@ -1,5 +1,6 @@
 .mainPart {
     display: flex;
+    align-items: center;
 }
 
 .splits {
@@ -11,14 +12,13 @@
 }
 
 .end {
+    width: 7vw;
+    height: 88vh;
     padding-top: 3vh;
     padding-right: 3vw;
     display: flex;
     flex-direction: column;
-    justify-content: flex-end;
-    align-items: flex-start;
-    width: 100%;
-    height: 100%;
+    align-items: end;
 }
 
 .closeButton {
@@ -37,11 +37,11 @@
     position: absolute;
     flex-direction: column;
     gap: 10px;
-    justify-content: flex-start;
     width: 130px;
     margin-top: 10px;
+    right: 15px;
     bottom: 20px;
-    right: 40px;
+    align-items: end;
 }
 
 .editButtons {

--- a/client/src/components/JoinSession/JoinSession.css
+++ b/client/src/components/JoinSession/JoinSession.css
@@ -1,7 +1,5 @@
-
 .mainPart {
     display: flex;
-    align-items: center;
 }
 
 .splits {
@@ -13,15 +11,15 @@
 }
 
 .end {
-    width: 7vw;
-    height: 88vh;
     padding-top: 3vh;
     padding-right: 3vw;
     display: flex;
     flex-direction: column;
-    align-items: end;
+    justify-content: flex-end;
+    align-items: flex-start;
+    width: 100%;
+    height: 100%;
 }
-
 
 .closeButton {
     color: #aaa;
@@ -30,7 +28,29 @@
     cursor: pointer;
 }
 
-.placeholder-image{
+.placeholder-image {
     height: 15vh;
     width: auto;
+}
+
+.buttonWrapper {
+    position: absolute;
+    flex-direction: column;
+    gap: 10px;
+    justify-content: flex-start;
+    width: 130px;
+    margin-top: 10px;
+    bottom: 20px;
+    right: 40px;
+}
+
+.editButtons {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    margin-top: 15px;
+    margin-bottom: 10px;
+    justify-content: flex-start;
+    height: 30px;
+    width: 100px;
 }

--- a/client/src/components/JoinSession/JoinSession.jsx
+++ b/client/src/components/JoinSession/JoinSession.jsx
@@ -8,13 +8,15 @@ import { Link, useLocation } from "react-router-dom";
 import "react-chat-elements/dist/main.css"
 import { MessageList, Input } from "react-chat-elements"
 import Button from "@mui/material/Button";
-import { addChatAsync } from "../../redux/chat/chatThunks";
+import { deleteSessionAsync } from "../../redux/session/sessionThunks";
 import Map from "./Map"
+import { useNavigate } from "react-router-dom";
 import { getChatAsync, updateChatAsync } from "../../redux/chat/chatThunks";
 const listReference = React.createRef();
 const inputReference = React.createRef();
 
 export default function JoinSession() {
+    const navigate = useNavigate();
     const location = useLocation();
     const dispatch = useDispatch();
     const searchParams = new URLSearchParams(location.search);
@@ -74,6 +76,13 @@ export default function JoinSession() {
             }
         });
     }
+
+    const handleDeleteSession = async () => {
+        dispatch(deleteSessionAsync(groupId)).then(() => {
+            navigate("/dashboard");
+            navigate(0);
+        })
+    };
 
     return (
         <div className="container">
@@ -140,7 +149,7 @@ export default function JoinSession() {
                     </Box>
                 </div>
                 <div className="splits">
-                    <Map session={session}/>
+                    <Map session={session} />
                 </div>
                 <div className="end">
                     <Link to={{ pathname: '/dashboard' }} style={{ marginRight: '10px', textDecoration: 'none' }}>
@@ -149,6 +158,25 @@ export default function JoinSession() {
                         </span>
                     </Link>
 
+                    {session.owner === profile.email && (
+                        <Button
+                            sx={{
+                                color: 'white',
+                                backgroundColor: 'red',
+                                '&:hover': {
+                                    backgroundColor: '#ff0000'
+                                },
+                                textTransform: 'none',
+                                position: 'absolute',
+                                bottom: '10px',
+                                right: '10px',
+                            }}
+                            variant="contained"
+                            onClick={handleDeleteSession}
+                        >
+                            Delete Session
+                        </Button>
+                    )}
                 </div>
             </div>
         </div>

--- a/client/src/components/JoinSession/JoinSession.jsx
+++ b/client/src/components/JoinSession/JoinSession.jsx
@@ -11,6 +11,7 @@ import Button from "@mui/material/Button";
 import { updateSessionAsync, deleteSessionAsync } from "../../redux/session/sessionThunks";
 import Map from "./Map"
 import { getChatAsync, updateChatAsync } from "../../redux/chat/chatThunks";
+import GooglePlacesAutocomplete from 'react-google-places-autocomplete';
 const listReference = React.createRef();
 const inputReference = React.createRef();
 
@@ -102,6 +103,10 @@ export default function JoinSession() {
         });
     };
 
+    const handleGoogleAutocompleteChange = async (location) => {
+        setEditedSession({ ...editedSession, location: location.label })
+    };
+
     return (
         <div className="container">
             <Navbar />
@@ -123,13 +128,15 @@ export default function JoinSession() {
                         )}
                         <h5>Location</h5>
                         {isEditable ? (
-                            <input
-                                type="text"
-                                value={editedSession.location}
-                                onChange={(e) =>
-                                    setEditedSession({ ...editedSession, location: e.target.value })
-                                }
-                            />
+                            <div>
+                                <GooglePlacesAutocomplete
+                                    apiKey={process.env.REACT_APP_GOOGLE_MAPS_API}
+                                    selectProps={{
+                                        onChange: handleGoogleAutocompleteChange,
+                                        placeholder: editedSession.location,
+                                    }}
+                                />
+                            </div>
                         ) : (
                             <h4>{curSession.location}</h4>
                         )}

--- a/client/src/components/JoinSession/JoinSession.jsx
+++ b/client/src/components/JoinSession/JoinSession.jsx
@@ -1,16 +1,15 @@
 import './JoinSession.css';
 import Navbar from '../Navbar/Navbar.jsx';
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import "react-chat-elements/dist/main.css"
 import { MessageList, Input } from "react-chat-elements"
 import Button from "@mui/material/Button";
-import { deleteSessionAsync } from "../../redux/session/sessionThunks";
+import { updateSessionAsync, deleteSessionAsync } from "../../redux/session/sessionThunks";
 import Map from "./Map"
-import { useNavigate } from "react-router-dom";
 import { getChatAsync, updateChatAsync } from "../../redux/chat/chatThunks";
 const listReference = React.createRef();
 const inputReference = React.createRef();
@@ -22,10 +21,10 @@ export default function JoinSession() {
     const searchParams = new URLSearchParams(location.search);
     const groupId = searchParams.get('groupId');
     const sessions = useSelector(state => state.sessionReducer).sessions;
-    const session = sessions.find(element => element.groupId == groupId);
+    const session = sessions.find(element => element.groupId === groupId);
     const profile = useSelector(state => state.profileReducer).profile;
     let chats = useSelector(state => state.chatReducer).chats;
-    let chat = chats.find(element => element.groupId == groupId)
+    let chat = chats.find(element => element.groupId === groupId)
     if (chat === undefined) {
         chat = []
     } else {
@@ -34,6 +33,10 @@ export default function JoinSession() {
             sortChat()
         }
     }
+
+    const [isEditable, setIsEditable] = useState(false);
+    const [editedSession, setEditedSession] = useState({ ...session });
+    const [curSession, setCurSession] = useState({ ...session });
 
     useEffect(() => {
         const intervalId = setInterval(() => {
@@ -77,11 +80,26 @@ export default function JoinSession() {
         });
     }
 
+    const handleEditSession = () => {
+        setIsEditable(true);
+    };
+
+    const handleCancelEdit = () => {
+        setIsEditable(false);
+        setEditedSession({ ...curSession });
+    };
+
+    const handleSaveEdit = () => {
+        dispatch(updateSessionAsync(editedSession));
+        setIsEditable(false);
+        setCurSession(editedSession);
+    };
+
     const handleDeleteSession = async () => {
         dispatch(deleteSessionAsync(groupId)).then(() => {
             navigate("/dashboard");
             navigate(0);
-        })
+        });
     };
 
     return (
@@ -90,21 +108,94 @@ export default function JoinSession() {
             <div className="mainPart">
                 <div className="splits">
                     <div className="mainInfo">
-                        <img className="placeholder-image" src={session.image} alt="placeholder" />
+                        <img className="placeholder-image" src={curSession.image} alt="placeholder" />
                         <h5>Event</h5>
-                        <h4>{session.name}</h4>
+                        {isEditable ? (
+                            <input
+                                type="text"
+                                value={editedSession.name}
+                                onChange={(e) =>
+                                    setEditedSession({ ...editedSession, name: e.target.value })
+                                }
+                            />
+                        ) : (
+                            <h4>{curSession.name}</h4>
+                        )}
                         <h5>Location</h5>
-                        <h4>{session.location}</h4>
+                        {isEditable ? (
+                            <input
+                                type="text"
+                                value={editedSession.location}
+                                onChange={(e) =>
+                                    setEditedSession({ ...editedSession, location: e.target.value })
+                                }
+                            />
+                        ) : (
+                            <h4>{curSession.location}</h4>
+                        )}
                         <h5>City</h5>
-                        <h4>{session.city}</h4>
-                        <h4>{session.description}</h4>
+                        {isEditable ? (
+                            <input
+                                type="text"
+                                value={editedSession.city}
+                                onChange={(e) =>
+                                    setEditedSession({ ...editedSession, city: e.target.value })
+                                }
+                            />
+                        ) : (
+                            <h4>{curSession.city}</h4>
+                        )}
+                        <h5>Description</h5>
+                        {isEditable ? (
+                            <input
+                                type="text"
+                                value={editedSession.description}
+                                onChange={(e) =>
+                                    setEditedSession({ ...editedSession, description: e.target.value })
+                                }
+                            />
+                        ) : (
+                            <h4>{curSession.description}</h4>
+                        )}
+                        {isEditable && (
+                            <div className="editButtons">
+                                <Button
+                                    sx={{
+                                        color: "white",
+                                        backgroundColor: "#DD4D2B",
+                                        "&:hover": {
+                                            backgroundColor: "#ab371b",
+                                        },
+                                        textTransform: "none",
+                                    }}
+                                    variant="contained"
+                                    onClick={handleSaveEdit}
+                                >
+                                    Save
+                                </Button>
+                                <Button
+                                    sx={{
+                                        color: "white",
+                                        backgroundColor: "#DD4D2B",
+                                        "&:hover": {
+                                            backgroundColor: "#ab371b",
+                                        },
+                                        textTransform: "none",
+                                    }}
+                                    variant="contained"
+                                    onClick={handleCancelEdit}
+                                >
+                                    Cancel
+                                </Button>
+                            </div>
+                        )}
                     </div>
                     <Divider />
                     <div className="equipmentInfo">
                         <h5>Equipment Needed</h5>
-                        <h4>{session.equipment}</h4>
+                        <h4>{curSession.equipment}</h4>
                         <h5>Players Needed</h5>
-                        <h4>{session.playersNeeded}</h4>
+                        <h4>{curSession.playersNeeded}</h4>
                     </div>
                 </div>
                 <div className="splits">
@@ -151,32 +242,49 @@ export default function JoinSession() {
                 <div className="splits">
                     <Map session={session} />
                 </div>
+                <div className="ownerButtons">
+                    {session.owner === profile.email && (
+                        <div className="buttonWrapper">
+                            {!isEditable && (
+                                <Button
+                                    sx={{
+                                        color: "white",
+                                        backgroundColor: "#DD4D2B",
+                                        "&:hover": {
+                                            backgroundColor: "#ab371b",
+                                        },
+                                        textTransform: "none",
+                                        marginBottom: "10px"
+                                    }}
+                                    variant="contained"
+                                    onClick={handleEditSession}
+                                >
+                                    Update Session
+                                </Button>
+                            )}
+                            <Button
+                                sx={{
+                                    color: "white",
+                                    backgroundColor: "#ff0000",
+                                    "&:hover": {
+                                        backgroundColor: "#bf0000",
+                                    },
+                                    textTransform: "none",
+                                }}
+                                variant="contained"
+                                onClick={handleDeleteSession}
+                            >
+                                Delete Session
+                            </Button>
+                        </div>
+                    )}
+                </div>
                 <div className="end">
                     <Link to={{ pathname: '/dashboard' }} style={{ marginRight: '10px', textDecoration: 'none' }}>
                         <span className="closeButton">
                             &times;
                         </span>
                     </Link>
-
-                    {session.owner === profile.email && (
-                        <Button
-                            sx={{
-                                color: 'white',
-                                backgroundColor: 'red',
-                                '&:hover': {
-                                    backgroundColor: '#ff0000'
-                                },
-                                textTransform: 'none',
-                                position: 'absolute',
-                                bottom: '10px',
-                                right: '10px',
-                            }}
-                            variant="contained"
-                            onClick={handleDeleteSession}
-                        >
-                            Delete Session
-                        </Button>
-                    )}
                 </div>
             </div>
         </div>

--- a/client/src/components/JoinSession/Map.jsx
+++ b/client/src/components/JoinSession/Map.jsx
@@ -7,9 +7,11 @@ const containerStyle = {
 };
 
 export default function Map(props) {
+  const [ libraries ] = useState(['places']);
   const [center, setCenter] = useState(null);
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API,
+    libraries: libraries
   });
 
   useEffect(() => {

--- a/client/src/redux/session/actionTypes.js
+++ b/client/src/redux/session/actionTypes.js
@@ -3,5 +3,6 @@ export const actionTypes = {
     GET_FEATURED_SESSIONS: 'session/getfeaturedsessions',
     GET_RECOMMENDED_SESSION: 'session/getrecommendedsession',
     CREATE_NEW_SESSION: 'session/createnewsession',
-    UPDATE_SESSION: 'session/updatesession'
+    UPDATE_SESSION: 'session/updatesession',
+    DELETE_SESSION: 'session/deletesession'
 };

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { REQUEST_STATE } from '../utils';
-import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync, updateSessionAsync } from './sessionThunks';
+import { getSessionsAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync, updateSessionAsync, deleteSessionAsync } from './sessionThunks';
 import sessionService from './sessionService';
 import profileService from '../profile/profileService'
 
@@ -19,6 +19,7 @@ const INITIAL_STATE = {
     getRecommendedSession: REQUEST_STATE.IDLE,
     createNewSession: REQUEST_STATE.IDLE,
     updateSession: REQUEST_STATE.IDLE,
+    deleteSession: REQUEST_STATE.IDLE,
     error: null
 };
 
@@ -138,6 +139,32 @@ const sessionSlice = createSlice({
                 return {
                     ...state,
                     updateSession: REQUEST_STATE.REJECTED,
+                    error: action.error
+                }
+            })
+            .addCase(deleteSessionAsync.pending, (state) => {
+                return {
+                    ...state,
+                    deleteSession: REQUEST_STATE.PENDING,
+                    error: null
+                }
+            })
+            .addCase(deleteSessionAsync.fulfilled, (state, action) => {
+                const groupId = action.payload;
+                const updatedSessions = state.sessions.filter(
+                    (session) => session.groupId !== groupId
+                );
+
+                return {
+                    ...state,
+                    deleteSession: REQUEST_STATE.FULFILLED,
+                    sessions: updatedSessions
+                };
+            })
+            .addCase(deleteSessionAsync.rejected, (state, action) => {
+                return {
+                    ...state,
+                    deleteSession: REQUEST_STATE.REJECTED,
                     error: action.error
                 }
             });

--- a/client/src/redux/session/sessionService.js
+++ b/client/src/redux/session/sessionService.js
@@ -66,10 +66,19 @@ const updateSession = async (session) => {
     return await response.json()
 }
 
+const deleteSession = async (groupId) => {
+    var response = await fetch(`${process.env.REACT_APP_REST_API_URL}/session/${groupId}`, {
+        method: "DELETE"
+    })
+
+    return await response.json()
+}
+
 export default {
     getSessions,
     getFeaturedSessions,
     getRecommendedSession,
     createNewSession,
-    updateSession
+    updateSession,
+    deleteSession
 };

--- a/client/src/redux/session/sessionThunks.js
+++ b/client/src/redux/session/sessionThunks.js
@@ -36,3 +36,10 @@ export const updateSessionAsync = createAsyncThunk(
         return await sessionService.updateSession(session);
     }
 );
+
+export const deleteSessionAsync = createAsyncThunk(
+    actionTypes.DELETE_SESSION,
+    async (groupId) => {
+        return await sessionService.deleteSession(groupId);
+    }
+);

--- a/server/mongo/models/sessionModel.js
+++ b/server/mongo/models/sessionModel.js
@@ -42,6 +42,10 @@ const sessionSchema = new mongoose.Schema({
         type: [],
         required: true,
     },
+    owner: {
+        type: String,
+        required: false
+    },
     dateTime: {
         type: Date,
         required: true,

--- a/server/mongo/queries/sessionQueries.js
+++ b/server/mongo/queries/sessionQueries.js
@@ -20,6 +20,7 @@ const sessionQueries = {
             image: session.image,
             sport: session.sport,
             members: session.members,
+            owner: session.owner,
             dateTime: session.dateTime
         });
         newSession.save()
@@ -43,6 +44,7 @@ const sessionQueries = {
                 image: session.image,
                 sport: session.sport,
                 members: session.members,
+                owner: session.owner,
                 dateTime: session.date
             },
             { new: true })

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -204,9 +204,13 @@ router.post('/recommended', function (req, res, next) {
 // DELETE a session
 router.delete('/:groupId', async function (req, res, next) {
     let groupId = req.params.groupId;
-    await sessionQueries.deleteSession(groupId);
 
-    return res.status(200).send(groupId);
+    try {
+        await sessionQueries.deleteSession(groupId);
+        return res.status(200).send(groupId);
+    } catch(err) {
+        return res.status(500).send('Internal server error.');
+    }
 });
 
 module.exports = router;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -201,4 +201,12 @@ router.post('/recommended', function (req, res, next) {
     return res.status(200).send(session);
 });
 
+// DELETE a session
+router.delete('/:groupId', async function (req, res, next) {
+    let groupId = req.params.groupId;
+    await sessionQueries.deleteSession(groupId);
+
+    return res.status(200).send(groupId);
+});
+
 module.exports = router;


### PR DESCRIPTION
Now when a new session is created, creator profile automatically set as session owner.

Session owner sees two new buttons in bottom right: Update and Delete.

Update allows for session fields on the left to be editable. Editing the location field uses google autocomplete + updates the map. Click save to save changes and cancel to revert back to original.

Delete button removes the session.


https://github.com/srujanr40/dogfish/assets/57128248/7eafebb2-0d85-47fb-ad4c-acfe271e5e16
