### PR TITLE
Some Bugfixes/sport specific session sections update

### DIFF
--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -20,13 +20,15 @@ export default function Dashboard() {
   const dispatch = useDispatch();
 
   const [nearYouSessions, setNearYouSessions] = useState([]);
-  const [frisbeeSessions, setFrisbeeSessions] = useState([]);
-  const [soccerSessions, setSoccerSessions] = useState([]);
+  const [interestedSportsSessions, setInterestedSportsSessions] = useState([]);
 
   useEffect(() => {
-    setFrisbeeSessions(sessions.filter((session) => session.sport.toLowerCase() === 'frisbee'));
-    setSoccerSessions(sessions.filter((session) => session.sport.toLowerCase() === 'soccer'));
-  }, [dispatch, sessions]);
+    let sportCategoriesArrays = [];
+    profile.interests.forEach((sport) => {
+      sportCategoriesArrays.push(sessions.filter((session) => session.sport.toLowerCase() === sport.toLowerCase()))
+    })
+    setInterestedSportsSessions(sportCategoriesArrays)
+  }, [dispatch, sessions, profile.interests]);
 
   useEffect(() => {
     dispatch(getSessionsNearYouAsync(profile.location))
@@ -75,8 +77,9 @@ export default function Dashboard() {
       <div className="sessionsContainer">
         <Card sessions={sessions} name={'All'} />
         <Card sessions={nearYouSessions} name={'Activities near you'} />
-        <Card sessions={frisbeeSessions} name={'Frisbee'} />
-        <Card sessions={soccerSessions} name={'Soccer'} />
+        {interestedSportsSessions.map((sessionsArray, index) => (
+          sessionsArray && sessionsArray[0] && <Card key={index} sessions={sessionsArray} name={sessionsArray[0].sport} />
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 export default function Dashboard() {
 
+  const sessions = useSelector(state => state.sessionReducer).sessions;
   const profile = useSelector(state => state.profileReducer).profile;
   const [isCreateSessionModalOpen, setIsCreateSessionModalOpen] =
     useState(false);
@@ -21,27 +22,8 @@ export default function Dashboard() {
   const [nearYouSessions, setNearYouSessions] = useState([]);
   const [frisbeeSessions, setFrisbeeSessions] = useState([]);
   const [soccerSessions, setSoccerSessions] = useState([]);
-  const [allSessions, setAllSessions] = useState([]);
 
   useEffect(() => {
-    dispatch(getSessionsAsync(''))
-    .then((sessions) => {
-      const all = sessions.payload
-      setAllSessions(all);
-    })
-    .catch((error) => {
-      console.error('Error fetching near you sessions:', error);
-    });
-
-    dispatch(getSessionsNearYouAsync(profile.location))
-      .then((sessions) => {
-        const near_you = sessions.payload
-        setNearYouSessions(near_you);
-      })
-      .catch((error) => {
-        console.error('Error fetching near you sessions:', error);
-      });
-
     dispatch(getSessionsAsync('Frisbee'))
       .then((sessions) => {
         const frisbeeSessionsData = sessions.payload;
@@ -52,14 +34,25 @@ export default function Dashboard() {
       });
 
     dispatch(getSessionsAsync('Soccer'))
-    .then((sessions) => {
-      const soccer = sessions.payload;
-      setSoccerSessions(soccer);
-    })
-    .catch((error) => {
-      console.error('Error fetching Frisbee sessions:', error);
-    });
-  }, [dispatch, allSessions, profile.location]);
+      .then((sessions) => {
+        const soccer = sessions.payload;
+        setSoccerSessions(soccer);
+      })
+      .catch((error) => {
+        console.error('Error fetching Frisbee sessions:', error);
+      });
+  }, [dispatch, sessions]);
+
+  useEffect(() => {
+    dispatch(getSessionsNearYouAsync(profile.location))
+      .then((sessions) => {
+        const near_you = sessions.payload
+        setNearYouSessions(near_you);
+      })
+      .catch((error) => {
+        console.error('Error fetching near you sessions:', error);
+      });
+  }, [dispatch, sessions, profile.location]);
 
   const openCreateSessionModal = () => {
     setIsCreateSessionModalOpen(true);
@@ -95,10 +88,10 @@ export default function Dashboard() {
         <Featured />
       </div>
       <div className="sessionsContainer">
+        <Card sessions={sessions} name={'All'} />
         <Card sessions={nearYouSessions} name={'Activities near you'} />
         <Card sessions={frisbeeSessions} name={'Frisbee'} />
         <Card sessions={soccerSessions} name={'Soccer'} />
-        <Card sessions={allSessions} name={'All'} />
       </div>
     </div>
   );

--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -7,7 +7,7 @@ import "../styles.module.css";
 import Fab from "@mui/material/Fab";
 import AddIcon from "@mui/icons-material/Add";
 import CreateSessionPopup from "../CreateSession/CreateSessionPopup.jsx";
-import { getSessionsAsync, getSessionsNearYouAsync } from "../../redux/session/sessionThunks.js";
+import { getSessionsNearYouAsync } from "../../redux/session/sessionThunks.js";
 import { useDispatch, useSelector } from "react-redux";
 
 export default function Dashboard() {
@@ -24,23 +24,8 @@ export default function Dashboard() {
   const [soccerSessions, setSoccerSessions] = useState([]);
 
   useEffect(() => {
-    dispatch(getSessionsAsync('Frisbee'))
-      .then((sessions) => {
-        const frisbeeSessionsData = sessions.payload;
-        setFrisbeeSessions(frisbeeSessionsData);
-      })
-      .catch((error) => {
-        console.error('Error fetching Frisbee sessions:', error);
-      });
-
-    dispatch(getSessionsAsync('Soccer'))
-      .then((sessions) => {
-        const soccer = sessions.payload;
-        setSoccerSessions(soccer);
-      })
-      .catch((error) => {
-        console.error('Error fetching Frisbee sessions:', error);
-      });
+    setFrisbeeSessions(sessions.filter((session) => session.sport.toLowerCase() === 'frisbee'));
+    setSoccerSessions(sessions.filter((session) => session.sport.toLowerCase() === 'soccer'));
   }, [dispatch, sessions]);
 
   useEffect(() => {

--- a/client/src/components/Navbar/Navbar.jsx
+++ b/client/src/components/Navbar/Navbar.jsx
@@ -107,11 +107,14 @@ export default function Navbar() {
               inputProps={{ 'aria-label': 'search' }}
             />
           </Search>
-          <Link to={`/join?groupId=${recommendedSession.groupId}`} style={{ color: 'white' }}>
-            <MenuItem onClick={updateSession}>
-              Magic Join
-            </MenuItem>
-          </Link>
+          <div>
+            {recommendedSession && <Link to={`/join?groupId=${recommendedSession.groupId}`} style={{ color: 'white' }}>
+              <MenuItem onClick={updateSession}>
+                Magic Join
+              </MenuItem>
+            </Link>
+            }
+            </div>
           <Link to="/mysessions" style={{ color: 'white' }}>
             <MenuItem>
               My Sessions

--- a/client/src/redux/profile/profileService.js
+++ b/client/src/redux/profile/profileService.js
@@ -1,6 +1,5 @@
 const getProfile = async () => {
     const email = localStorage.getItem("currentUser");
-    console.log(email);
     try {
         const url = `${process.env.REACT_APP_REST_API_URL}/profile?email=${encodeURIComponent(email)}`;
         const response = await fetch(url, {

--- a/client/src/redux/session/actionTypes.js
+++ b/client/src/redux/session/actionTypes.js
@@ -1,4 +1,5 @@
 export const actionTypes = {
+    GET_ALL_SESSIONS: 'session/getallsessions',
     GET_SESSIONS: 'session/getsessions',
     GET_SESSIONS_NEAR_YOU: 'session/getsessionsnearyou',
     GET_FEATURED_SESSIONS: 'session/getfeaturedsessions',

--- a/client/src/redux/session/sessionReducer.js
+++ b/client/src/redux/session/sessionReducer.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { REQUEST_STATE } from '../utils';
-import { getSessionsAsync, getSessionsNearYouAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync, updateSessionAsync, deleteSessionAsync } from './sessionThunks';
+import { getAllSessionsAsync, getSessionsAsync, getSessionsNearYouAsync, getFeaturedSessionsAsync, getRecommendedSessionAsync, createNewSessionAsync, updateSessionAsync, deleteSessionAsync } from './sessionThunks';
 import sessionService from './sessionService';
 import profileService from '../profile/profileService'
 
@@ -14,6 +14,7 @@ const INITIAL_STATE = {
     sessions: sessions,
     featuredSessions: await featuredSessions,
     recommendedSession: featuredSessions[0],
+    getAllSessions: REQUEST_STATE.IDLE,
     getSessions: REQUEST_STATE.IDLE,
     getSessionsNearYou: REQUEST_STATE.IDLE,
     getFeaturedSessions: REQUEST_STATE.IDLE,
@@ -30,6 +31,27 @@ const sessionSlice = createSlice({
     reducers: {},
     extraReducers: (builder) => {
         builder
+            .addCase(getAllSessionsAsync.pending, (state) => {
+                return {
+                    ...state,
+                    getAllSessions: REQUEST_STATE.PENDING,
+                    error: null
+                }
+            })
+            .addCase(getAllSessionsAsync.fulfilled, (state, action) => {
+                return {
+                    ...state,
+                    getAllSessions: REQUEST_STATE.FULFILLED,
+                    sessions: action.payload
+                }
+            })
+            .addCase(getAllSessionsAsync.rejected, (state, action) => {
+                return {
+                    ...state,
+                    getAllSessions: REQUEST_STATE.REJECTED,
+                    error: action.error
+                }
+            })
             .addCase(getSessionsAsync.pending, (state) => {
                 return {
                     ...state,
@@ -40,8 +62,7 @@ const sessionSlice = createSlice({
             .addCase(getSessionsAsync.fulfilled, (state, action) => {
                 return {
                     ...state,
-                    getSessions: REQUEST_STATE.FULFILLED,
-                    sessions: action.payload
+                    getSessions: REQUEST_STATE.FULFILLED
                 }
             })
             .addCase(getSessionsAsync.rejected, (state, action) => {
@@ -61,8 +82,7 @@ const sessionSlice = createSlice({
             .addCase(getSessionsNearYouAsync.fulfilled, (state, action) => {
                 return {
                     ...state,
-                    getSessions: REQUEST_STATE.FULFILLED,
-                    sessions: action.payload
+                    getSessions: REQUEST_STATE.FULFILLED
                 }
             })
             .addCase(getSessionsNearYouAsync.rejected, (state, action) => {

--- a/client/src/redux/session/sessionThunks.js
+++ b/client/src/redux/session/sessionThunks.js
@@ -2,6 +2,13 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { actionTypes } from './actionTypes';
 import sessionService from "./sessionService"
 
+export const getAllSessionsAsync = createAsyncThunk(
+    actionTypes.GET_ALL_SESSIONS,
+    async () => {
+        return await sessionService.getSessions();
+    }
+);
+
 export const getSessionsAsync = createAsyncThunk(
     actionTypes.GET_SESSIONS,
     async (filter) => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -45,7 +45,6 @@ router.post('/', async (req, res) => {
       if (!profile) {
         return res.status(400).json({ error: 'Invalid email or password' });
       }
-      console.log(profile);
   
       // Compare the provided password with the hashed password stored in the database
       const passwordMatch = await bcrypt.compare(password, profile.password);


### PR DESCRIPTION
- I made it so that only getting all sessions changes the sessions state in the reducer (fixes buggy sessions list)
- I got rid of API calls containing MongoDB calls from filtering. Now filtering just happens by filtering the existing sessions array (speeds up loading time)
- Added functionality where instead of just having a soccer and frisbee section for everyone, it instead displays sections dynamically matching the logged in profile's interests. These sections update dynamically with new sessions and new profile interests
- I deleted existing messy sessions and added a bunch of filled out sessions that look nice for our demo. In doing so, I noticed that there was a small null check missing from the navbar that caused errors when there were no sessions, so I fixed that.
- I moved the all sessions section to the top because that made more sense to me.
- Removed a couple of console logs
- Through the above changes, the infinite API calls bug has also disappeared.
- I also made it so that updating one's profile location only triggers the near me session section to reload instead of all sections, which speeds up the site.